### PR TITLE
09 get guilds#15

### DIFF
--- a/app/controllers/api/v1/oauths_controller.rb
+++ b/app/controllers/api/v1/oauths_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::OauthsController < Api::V1::BaseController
+  require 'net/http'
+  require 'uri'
 
   def oauth
     login_at(auth_params[:provider])
@@ -17,6 +19,7 @@ class Api::V1::OauthsController < Api::V1::BaseController
       )
     else
       fetch_user_data_from(provider)
+      get_guilds
     end
     redirect_to mypage_path, success: t('.success')
   end
@@ -29,7 +32,6 @@ class Api::V1::OauthsController < Api::V1::BaseController
 
   def fetch_user_data_from(provider)
     user_from_provider = build_from(provider)
-    binding.pry
     user = User.find_or_initialize_by(discord_id: user_from_provider.discord_id)
     @user.build_authentication(uid: @user_hash[:uid],
                                provider: provider,
@@ -38,5 +40,28 @@ class Api::V1::OauthsController < Api::V1::BaseController
     @user.save!
     reset_session
     auto_login(@user)
+  end
+
+  def get_guilds
+    token = current_user.authentication.access_token
+    uri = URI.parse("https://discord.com/api/v8/users/@me/guilds")
+    req = Net::HTTP::Get.new(uri)
+    req['authorization'] = "Bearer #{token}"
+    req_options = {
+      use_ssl: uri.scheme == 'https'
+    }
+    response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+      http.request(req)
+    end
+    results = JSON.parse(response.body)
+    results.each do |result|
+      guild_id = result["id"].to_i
+      guild_name = result["name"]
+      #なぜかIDがguild_idで保存される
+      guild = Guild.new(name: guild_name, uuid: guild_id)
+      guild.save
+      user_guild = UserGuild.new(user_id: current_user.id, guild_id: guild.id)
+      user_guild.save
+    end
   end
 end

--- a/app/controllers/api/v1/oauths_controller.rb
+++ b/app/controllers/api/v1/oauths_controller.rb
@@ -29,6 +29,7 @@ class Api::V1::OauthsController < Api::V1::BaseController
 
   def fetch_user_data_from(provider)
     user_from_provider = build_from(provider)
+    binding.pry
     user = User.find_or_initialize_by(discord_id: user_from_provider.discord_id)
     @user.build_authentication(uid: @user_hash[:uid],
                                provider: provider,

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,5 +2,7 @@ class HomeController < ApplicationController
 
   def index; end
 
-  def mypage; end
+  def mypage
+    @guilds = current_user.guilds
+  end
 end

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -1,15 +1,16 @@
 class Authentication < ApplicationRecord
-  before_save :encrypt_access_token
+  # before_save :encrypt_access_token
   belongs_to :user
 
   validates :uid, presence: true
   validates :provider, presence: true
 
-  def encrypt_access_token
-    key_len = ActiveSupport::MessageEncryptor.key_len
-    secret = Rails.application.key_generator.generate_key('salt', key_len)
-    crypt = ActiveSupport::MessageEncryptor.new(secret)
-    self.access_token = crypt.encrypt_and_sign(access_token)
-    self.refresh_token = crypt.encrypt_and_sign(refresh_token)
-  end
+  #authenticationsテーブルのトークンを暗号化したら、APIリクエストできないためコメントアウト
+  # def encrypt_access_token
+  #   key_len = ActiveSupport::MessageEncryptor.key_len
+  #   secret = Rails.application.key_generator.generate_key('salt', key_len)
+  #   crypt = ActiveSupport::MessageEncryptor.new(secret)
+  #   self.access_token = crypt.encrypt_and_sign(access_token)
+  #   self.refresh_token = crypt.encrypt_and_sign(refresh_token)
+  # end
 end

--- a/app/models/guild.rb
+++ b/app/models/guild.rb
@@ -1,0 +1,4 @@
+class Guild < ApplicationRecord
+  has_many :user_guilds
+  has_many :users, through: :user_guilds
+end

--- a/app/models/guild.rb
+++ b/app/models/guild.rb
@@ -1,4 +1,15 @@
 class Guild < ApplicationRecord
-  has_many :user_guilds
-  has_many :users, through: :user_guilds
+  before_create :set_uuid
+
+  has_many :user_guilds, dependent: :destroy
+  has_many :users, through: :user_guilds, source: :user
+
+  private
+
+  def set_uuid
+    self.uuid = loop do
+      random_token = SecureRandom.urlsafe_base64(9)
+      break random_token unless self.class.exists?(uuid: random_token)
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,12 +1,17 @@
 class User < ApplicationRecord
+  require "net/http"
+  require "uri"
+  require "json"
+  require "openssl"
+
   before_create :set_uuid
 
   authenticates_with_sorcery!
   has_one :authentication, dependent: :destroy
   accepts_nested_attributes_for :authentication
 
-  has_many :user_guilds
-  has_many :guilds, through: :user_guilds
+  has_many :user_guilds, dependent: :destroy
+  has_many :guilds, through: :user_guilds, source: :guild
 
   validates :discord_id, presence: true, uniqueness: true
   validates :name, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,9 @@ class User < ApplicationRecord
   has_one :authentication, dependent: :destroy
   accepts_nested_attributes_for :authentication
 
+  has_many :user_guilds
+  has_many :guilds, through: :user_guilds
+
   validates :discord_id, presence: true, uniqueness: true
   validates :name, presence: true
   validates :email, presence: true

--- a/app/models/user_guild.rb
+++ b/app/models/user_guild.rb
@@ -1,0 +1,4 @@
+class UserGuild < ApplicationRecord
+  belongs_to :user
+  belongs_to :guild
+end

--- a/app/views/home/_guild.html.slim
+++ b/app/views/home/_guild.html.slim
@@ -1,0 +1,6 @@
+ul.nav.flex-column
+  = link_to guild.name, "#", class: 'nav-link'
+  li.nav-item.pl-5
+    = link_to 'チャンネル1', "#", class: 'nav-link'
+    = link_to 'チャンネル2', "#", class: 'nav-link'
+    = link_to 'チャンネル3', "#", class: 'nav-link'

--- a/app/views/home/mypage.html.slim
+++ b/app/views/home/mypage.html.slim
@@ -2,18 +2,7 @@ main
   .container-fluid
     .row
       .col-md-2.border-right.bg-white
-        ul.nav.flex-column
-          = link_to 'サーバーA', "#", class: 'nav-link'
-          li.nav-item.pl-5
-            = link_to 'チャンネル1', "#", class: 'nav-link'
-            = link_to 'チャンネル2', "#", class: 'nav-link'
-            = link_to 'チャンネル3', "#", class: 'nav-link'
-        ul.nav.flex-column
-          = link_to 'サーバーB', "#", class: 'nav-link'
-          li.nav-item.pl-5
-            = link_to 'チャンネル4', "#", class: 'nav-link'
-            = link_to 'チャンネル5', "#", class: 'nav-link'
-            = link_to 'チャンネル6', "#", class: 'nav-link'
+        = render partial: 'guild', collection: @guilds, as: :guild
 
       .col-md-10.contents
         .container-fluid.text-center

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -3,9 +3,12 @@ header.py-2
     .container-fluid
       = link_to 'Discord-Log', root_path, class: 'navbar-brand ml-5'
 
-      ul.navbar-nav
-        li.nav-item.mr-5
-          - if current_user
-            = link_to 'ログアウト', api_v1_logout_path, method: :delete, class: 'nav-link active'
+      ul.navbar-nav.justify-content-end
+        - if current_user
+          - if current_page?(root_path)
+            li= link_to 'マイページ', mypage_path, class: 'nav-link active'
           - else
-            = link_to 'ログイン', api_v1_auth_at_provider_path(:provider => :discord), class: 'nav-link active'
+            li= link_to 'ホーム', root_path, class: 'nav-link active'
+          li= link_to 'ログアウト', api_v1_logout_path, method: :delete, class: 'nav-link active'
+        - else
+          li= link_to 'ログイン', api_v1_auth_at_provider_path(:provider => :discord), class: 'nav-link active'

--- a/db/migrate/20210617024053_create_guilds.rb
+++ b/db/migrate/20210617024053_create_guilds.rb
@@ -1,0 +1,10 @@
+class CreateGuilds < ActiveRecord::Migration[6.0]
+  def change
+    create_table :guilds do |t|
+      t.string :name, null: false
+      t.string :uuid, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210617064550_create_user_guilds.rb
+++ b/db/migrate/20210617064550_create_user_guilds.rb
@@ -1,0 +1,10 @@
+class CreateUserGuilds < ActiveRecord::Migration[6.0]
+  def change
+    create_table :user_guilds do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :guild, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_14_062839) do
+ActiveRecord::Schema.define(version: 2021_06_17_064550) do
 
   create_table "authentications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -22,6 +22,22 @@ ActiveRecord::Schema.define(version: 2021_06_14_062839) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
     t.index ["user_id"], name: "index_authentications_on_user_id"
+  end
+
+  create_table "guilds", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "uuid", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "user_guilds", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "guild_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["guild_id"], name: "index_user_guilds_on_guild_id"
+    t.index ["user_id"], name: "index_user_guilds_on_user_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
@@ -36,4 +52,6 @@ ActiveRecord::Schema.define(version: 2021_06_14_062839) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "user_guilds", "guilds"
+  add_foreign_key "user_guilds", "users"
 end


### PR DESCRIPTION
## 概要

・サーバー情報を取得するために、Guildsテーブルを作成します。
・UserとGuildは多対多の関係なので、中間テーブルとしてuser_guildsテーブルを作成します。
・DiscordのAPIに、認証時に取得したaccess_tokenからURIにリクエストを投げて、取得した情報をDBに保存します。
・サイドバーにユーザーが所属しているサーバーを全て表示します。

## 確認方法

トップページからログインすると、ログイン後にマイページ画面が表示され、サイドバーにユーザーのサーバー情報が表示されているかどうかを確認します。

## チェックリスト

- [x] Guildsテーブル作成
- [x] usersテーブルとGuildsテーブルの中間テーブルuser_guildsテーブルを作成
- [x] Discordのサーバー情報をGuildsテーブルに保存する
- [x] ログイン後のマイページ画面のサイドバーにサーバー情報を表示する

## コメント

次回の実装で、ユーザーが所属しているサーバーのチャンネル情報を取得します。
ご確認をお願いします。