### PR TITLE
12 api endpoint#23

### DIFF
--- a/app/controllers/api/v1/channel_times_controller.rb
+++ b/app/controllers/api/v1/channel_times_controller.rb
@@ -1,0 +1,15 @@
+class Api::V1::ChannelTimesController < Api::V1::BaseController
+  protect_from_forgery with: :null_session
+
+  def create
+    puts "アクションが届いています。"
+    puts params
+    time = Time.new
+  end
+
+  private
+
+  def bot_params
+    params.permit(:user_id, :user_name, :channel_id, :channel_name)
+  end
+end

--- a/app/controllers/channel_times_controller.rb
+++ b/app/controllers/channel_times_controller.rb
@@ -1,7 +1,0 @@
-class ChannelTimesController < ApplicationController
-
-  def create
-    puts "アクションが届いています。"
-  end
-
-end

--- a/app/controllers/channel_times_controller.rb
+++ b/app/controllers/channel_times_controller.rb
@@ -1,0 +1,7 @@
+class ChannelTimesController < ApplicationController
+
+  def create
+    puts "アクションが届いています。"
+  end
+
+end

--- a/app/models/channel_time.rb
+++ b/app/models/channel_time.rb
@@ -1,0 +1,3 @@
+class ChannelTime < ApplicationRecord
+  belongs_to :user_channel
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
       get "oauth/callback", to: "oauths#callback"
       get "oauth/:provider", to: "oauths#oauth", as: :auth_at_provider
       delete 'logout', to: 'user_sessions#destroy'
+      post 'times', to: 'channel_time#create'
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
       get "oauth/callback", to: "oauths#callback"
       get "oauth/:provider", to: "oauths#oauth", as: :auth_at_provider
       delete 'logout', to: 'user_sessions#destroy'
-      post 'times', to: 'channel_time#create'
+      post 'times', to: 'channel_times#create'
     end
   end
 end

--- a/db/migrate/20210629074955_create_channel_times.rb
+++ b/db/migrate/20210629074955_create_channel_times.rb
@@ -1,0 +1,11 @@
+class CreateChannelTimes < ActiveRecord::Migration[6.0]
+  def change
+    create_table :channel_times do |t|
+      t.datetime :start_time
+      t.datetime :end_time
+      t.references :user_channel, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_22_043859) do
+ActiveRecord::Schema.define(version: 2021_06_29_074955) do
 
   create_table "authentications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -22,6 +22,15 @@ ActiveRecord::Schema.define(version: 2021_06_22_043859) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
     t.index ["user_id"], name: "index_authentications_on_user_id"
+  end
+
+  create_table "channel_times", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.datetime "start_time"
+    t.datetime "end_time"
+    t.bigint "user_channel_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_channel_id"], name: "index_channel_times_on_user_channel_id"
   end
 
   create_table "channels", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
@@ -71,6 +80,7 @@ ActiveRecord::Schema.define(version: 2021_06_22_043859) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "channel_times", "user_channels"
   add_foreign_key "channels", "guilds"
   add_foreign_key "user_channels", "channels"
   add_foreign_key "user_channels", "users"


### PR DESCRIPTION
## 概要

別アプリのRubyで作成したDiscordのBotアプリで音声チャンネルの入室、退出時に
本アプリのDiscord-Logのエンドポイントに対してPOSTリクエストを送信し、
createアクションでユーザー情報とチャンネル情報をパラメーターで受け取れるようにしました。

## 確認方法

RubyのDiscord_botを起動させ、サーバー内にDiscord-LogのBotがオンラインである状態で、
音声チャンネルに入室、退出をします。
そうすると、Discord-LogのRailsアプリケーションでユーザー情報とチャンネル情報がパラメーターで
送られてきているかを確認してください。

## チェックリスト

- [x] 音声チャンネルの入室、退出時に時間を計測するchannel_timesテーブルを作成
- [x] channel_timesコントローラーを作成し、createアクションを設ける
- [x] RubyアプリのDiscord-LogのBotからPOSTリクエストが受け取れるようにルーティングを設定
- [x] Botでイベントが発火したタイミングでパラメーターが受け取れているかを確認

## コメント

RubyアプリのBotは別アプリにあります。
ご確認をお願いします。