### PR TITLE
[Fix]herokuとbundlerのバージョンを合わせるよう設定

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,6 +186,8 @@ GEM
     nio4r (2.5.7)
     nokogiri (1.11.7-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.11.7-x86_64-linux)
+      racc (~> 1.4)
     oauth (0.5.6)
     oauth2 (1.4.7)
       faraday (>= 0.8, < 2.0)
@@ -351,6 +353,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-linux
 
 DEPENDENCIES
   better_errors


### PR DESCRIPTION
## 概要

herokuとbundlerのバージョンを合わせる設定しました。

## チェックリスト

- [x] bundle lock --add-platform x86_64-linux を実行

## コメント

ご確認お願いします。